### PR TITLE
chore: add env TARGET

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ const fg = require('fast-glob');
 
 require('dotenv-load')();
 
-const isProd = process.env.NODE_ENV === 'production';
+const isProd = process.env.TARGET === 'production';
 const siteUrl = isProd ? 'https://photos.klg.bz' : 'http://localhost:8000';
 const siteTitle = 'ek|photos';
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,7 +12,7 @@ const stat = promisify(fs.stat);
 
 const TMPL_DIR = path.join(__dirname, 'src', 'templates');
 
-const isProd = process.env.NODE_ENV === 'production';
+const isProd = process.env.TARGET === 'production';
 
 const pagesQuery = /* graphql */ `
   query pages($instanceName: String!, $directoryFilter: String) {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "predeploy": "NODE_ENV=production npm run build -- --prefix-paths",
+    "predeploy": "TARGET=production npm run build -- --prefix-paths",
     "deploy": "node ./script/deploy.js",
     "type-check": "tsc",
     "lint-js": "eslint '**/*.js' --config .eslintrc.js --quiet --fix --ignore-pattern '**/*.{ts,tsx}' --ignore-path .gitignore",

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -19,7 +19,7 @@ const FALLBACK_IMG =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAf' +
   'FcSJAAAADUlEQVR42mNcd+P/fwAIRwOGEN0VpwAAAABJRU5ErkJggg==';
 
-const isDevEnv = process.env.NODE_ENV !== 'production';
+const isDevEnv = process.env.TARGET !== 'production';
 
 export default class Map extends React.Component<Props, State> {
   constructor(props: Props) {


### PR DESCRIPTION
...as a replacement for NODE_ENV, which is set to "production" by default during builds, to speed up CI.